### PR TITLE
fix: use standard export statement

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
-export withKey from './with-key';
+import withKey from './with-key';
+export default withKey;


### PR DESCRIPTION
update index.js to ensure that the package exports `withKey` as `default`